### PR TITLE
Add 'encoding' option to allow overriding server encoding

### DIFF
--- a/src/BeSimple/SoapBundle/DependencyInjection/Configuration.php
+++ b/src/BeSimple/SoapBundle/DependencyInjection/Configuration.php
@@ -117,6 +117,8 @@ class Configuration
                                     ->thenInvalid(sprintf('The cache type has to be either %s', implode(', ', $this->cacheTypes)))
                                 ->end()
                             ->end()
+                            ->scalarNode('encoding')
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/BeSimple/SoapBundle/WebServiceContext.php
+++ b/src/BeSimple/SoapBundle/WebServiceContext.php
@@ -128,6 +128,10 @@ class WebServiceContext
             if (null !== $this->options['cache_type']) {
                 $this->serverBuilder->withWsdlCache($this->options['cache_type']);
             }
+
+            if (null !== $this->options['encoding']) {
+                $this->serverBuilder->withEncoding($this->options['encoding']);
+            }
         }
 
         return $this->serverBuilder;


### PR DESCRIPTION
I needed to change the `encoding` to `ISO-8859-1` and found no way to do it from the configuration so I added the option. Please tell me if there's a better way to do this or if its useful as I coded it.
