### PR TITLE
allow Symfony2.4+ versions and do not use self.version inside require, test different Symfony2 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
+  - 5.3
+  - 5.4
+  - 5.5
 
 env:
-    - SYMFONY_VERSION=2.0.*
-    - SYMFONY_VERSION=2.1.*
-    - SYMFONY_VERSION=2.2.*
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=dev-master
+  - SYMFONY_VERSION=2.0.*
+  - SYMFONY_VERSION=2.1.*
+  - SYMFONY_VERSION=2.2.*
+  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=dev-master
 
 before_script:
-    - composer require symfony/symfony:${SYMFONY_VERSION} --no-interaction --prefer-source
+  - composer require symfony/http-foundation:${SYMFONY_VERSION} --no-interaction --prefer-source
 
 script:
-    - phpunit --coverage-text
+  - phpunit --coverage-text
 
 matrix:
-    allow_failures:
-        - env: SYMFONY_VERSION=dev-master
+  allow_failures:
+    - env: SYMFONY_VERSION=dev-master

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-soap": "*",
         "ext-curl": "*",
         "ass/xmlsecurity": "dev-master",
-        "symfony/http-foundation": ">=2.0,<2.4-dev",
+        "symfony/http-foundation": "~2.0",
         "zendframework/zend-mail": "2.1.*",
         "zendframework/zend-mime": "2.1.*",
         "zendframework/zend-soap": "2.1.*"
@@ -39,8 +39,8 @@
     "require-dev": {
         "ext-mcrypt": "*",
         "mikey179/vfsStream": "dev-master",
-        "symfony/filesystem": ">=2.3,<2.4-dev",
-        "symfony/process": ">=2.3,<2.4-dev"
+        "symfony/filesystem": "~2.3",
+        "symfony/process": "~2.3"
     },
     "autoload": {
         "psr-0": { "BeSimple\\": "src/" }

--- a/src/BeSimple/SoapBundle/composer.json
+++ b/src/BeSimple/SoapBundle/composer.json
@@ -22,16 +22,16 @@
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",
-        "besimple/soap-common": "self.version",
+        "besimple/soap-common": "0.2.*",
         "ass/xmlsecurity": "dev-master",
         "zendframework/zend-mail": "2.1.*",
         "zendframework/zend-mime": "2.1.*",
         "zendframework/zend-soap": "2.1.*",
-        "symfony/http-foundation": ">=2.0,<2.4-dev"
+        "symfony/framework-bundle": "~2.0"
     },
     "suggest": {
-        "besimple/soap-client": "self.version",
-        "besimple/soap-server": "self.version"
+        "besimple/soap-client": "0.2.*",
+        "besimple/soap-server": "0.2.*"
     },
     "autoload": {
         "psr-0": { "BeSimple\\SoapBundle": "" }

--- a/src/BeSimple/SoapClient/composer.json
+++ b/src/BeSimple/SoapClient/composer.json
@@ -23,13 +23,13 @@
         "php": ">=5.3.0",
         "ext-soap": "*",
         "ext-curl": "*",
-        "besimple/soap-common": "self.version",
+        "besimple/soap-common": "0.2.*",
         "ass/xmlsecurity": "dev-master"
     },
     "require-dev": {
         "mikey179/vfsStream": "dev-master",
-        "symfony/filesystem": ">=2.3,<2.4-dev",
-        "symfony/process": ">=2.3,<2.4-dev"
+        "symfony/filesystem": "~2.3",
+        "symfony/process": "~2.3"
     },
     "autoload": {
         "psr-0": { "BeSimple\\SoapClient": "" }

--- a/src/BeSimple/SoapServer/composer.json
+++ b/src/BeSimple/SoapServer/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",
-        "besimple/soap-common": "self.version"
+        "besimple/soap-common": "0.2.*"
     },
     "autoload": {
         "psr-0": { "BeSimple\\SoapServer": "" }


### PR DESCRIPTION
the test runs are a bit flaky:
https://travis-ci.org/BeSimple/BeSimpleSoap/builds/11510059
https://travis-ci.org/BeSimple/BeSimpleSoap/builds/11508488
https://travis-ci.org/BeSimple/BeSimpleSoap/builds/11508409
