### PR TITLE
Fix byte length counting if strlen overloading used

### DIFF
--- a/src/BeSimple/SoapServer/SoapResponse.php
+++ b/src/BeSimple/SoapServer/SoapResponse.php
@@ -54,8 +54,15 @@ class SoapResponse extends CommonSoapResponse
         header('Content-Type: ' . $this->getContentType());
         // get content to send
         $response = $this->getContent();
+
         // set Content-Length header
-        header('Content-Length: '. strlen($response));
+        if (function_exists('mb_strlen')) {
+            $length = mb_strlen($response, '8bit');
+        } else {
+            $length = strlen($response);
+        }
+        header('Content-Length: ' . $length);
+
         // send response to client
         echo $response;
     }


### PR DESCRIPTION
Function strlen() counts characters instead of bytes if mbstring.func_overload is used in php.ini so Content-Length header gets a wrong value.

I changed strlen() call to mb_strlen() with "8bit" encoding as suggested here http://www.php.net/manual/ru/function.mb-strlen.php#77040

May be we can even get rid of setting Content-Length explicitly?
