### PR TITLE
Adding besimple/soap-wsdl to dependencies

### DIFF
--- a/src/BeSimple/SoapBundle/composer.json
+++ b/src/BeSimple/SoapBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.0",
         "ext-soap": "*",
         "besimple/soap-common": "0.2.*",
+        "besimple/soap-wsdl": "0.2.*",
         "ass/xmlsecurity": "dev-master",
         "zendframework/zend-mail": "2.1.*",
         "zendframework/zend-mime": "2.1.*",


### PR DESCRIPTION
Fix missing `BeSimple\SoapWsdl\Dumper\Dumper` class in `BeSimple\SoapBundle\WebServiceContext`
