### PR TITLE
allow zend-mime package >2.1.0, <2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ass/xmlsecurity": "~1.0",
         "symfony/framework-bundle": "~2.6",
         "symfony/twig-bundle": "~2.6",
-        "zendframework/zend-mime": "2.1.*"
+        "zendframework/zend-mime": "~2.1"
     },
     "replace": {
         "besimple/soap-bundle": "self.version",


### PR DESCRIPTION
There have been more recent ZF releases, which makes this package incompatible with other packages that use more recent ZF components.  This change liberalises the allowed versions of zendframework/zend-mime.
