### PR TITLE
Update Curl class to support CURLOPT_CAINFO and CURLOPT_CAPATH options

### DIFF
--- a/src/BeSimple/SoapClient/Curl.php
+++ b/src/BeSimple/SoapClient/Curl.php
@@ -95,6 +95,12 @@ class Curl
             curl_setopt($this->ch, CURLOPT_SSLCERT, $options['local_cert']);
             curl_setopt($this->ch, CURLOPT_SSLCERTPASSWD, $options['passphrase']);
         }
+        if (isset($options['ca_info'])) {
+            curl_setopt($this->ch, CURLOPT_CAINFO, $options['ca_info']);
+        }
+        if (isset($options['ca_path'])) {
+            curl_setopt($this->ch, CURLOPT_CAPATH, $options['ca_path']);
+        }
     }
 
     /**


### PR DESCRIPTION
Hello,

I needed support for CURLOPT_CAINFO and CURLOPT_CAPATH options so I added them.

Thank you all for this great library, it helped me a lot!

Regards,
Boris.
