### PR TITLE
Certificate passphrase error when not required

### DIFF
--- a/src/BeSimple/SoapClient/Curl.php
+++ b/src/BeSimple/SoapClient/Curl.php
@@ -105,7 +105,10 @@ class Curl
         }
         if (isset($options['local_cert'])) {
             curl_setopt($this->ch, CURLOPT_SSLCERT, $options['local_cert']);
-            curl_setopt($this->ch, CURLOPT_SSLCERTPASSWD, $options['passphrase']);
+
+            if (isset($options['passphrase'])) {
+                curl_setopt($this->ch, CURLOPT_SSLCERTPASSWD, $options['passphrase']);
+            }
         }
         if (isset($options['ca_info'])) {
             curl_setopt($this->ch, CURLOPT_CAINFO, $options['ca_info']);


### PR DESCRIPTION
When using digest authentication with SoapClient, the curl helper requires a passphrase for the given certificate, throwing an error if the passphrase is not set while it is not needed by the certificate itself.

We should'nt rely on this passphrase, as it isn't needed by the SoapClientBuilder itself.

This pull request adds the ability to make it optional.
