### PR TITLE
[SoapClient] Added ability to add cURL options later

### DIFF
--- a/src/BeSimple/SoapClient/SoapClient.php
+++ b/src/BeSimple/SoapClient/SoapClient.php
@@ -77,6 +77,13 @@ class SoapClient extends \SoapClient
     private $lastResponse = '';
 
     /**
+     * Additional cURLs options.
+     *
+     * @var array
+     */
+    private $requestOptions = array();
+
+    /**
      * Soap kernel.
      *
      * @var \BeSimple\SoapClient\SoapKernel
@@ -255,7 +262,20 @@ class SoapClient extends \SoapClient
      */
     protected function filterRequestOptions(SoapRequest $soapRequest)
     {
-        return array();
+        return $this->requestOptions;
+    }
+
+    /**
+     * Sets an additional cURL option for request.
+     *
+     * @param $key
+     * @param $value
+     *
+     * @return void
+     */
+    public function setRequestOption($key, $value)
+    {
+        $this->requestOptions[$key] = $value;
     }
 
     /**


### PR DESCRIPTION
It's very hard to implement those cURL constants and options into the existing client.builder service. It would be much easier to inject parameters later.

```
// example code
$this->client = $builder->build(); // $builder from DIC "besimple.soap.client.builder"
$this->client->setRequestOption(CURLOPT_SSL_VERIFYHOST, 0);
$this->client->setRequestOption(CURLOPT_SSL_VERIFYPEER, 0);
$response = $this->client->__soapCall($functionName, $arguments);
```

So I've added setRequestOption method to SoapClient.
