### PR TITLE
Mistyped property for SoapClient options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - composer self-update
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
   - composer update --no-interaction --prefer-source
+  - echo "always_populate_raw_post_data = -1" >> ~/.phpenv/versions/5.6/etc/php.ini
   - ./src/BeSimple/SoapClient/Tests/bin/phpwebserver.sh
   - ./src/BeSimple/SoapClient/Tests/bin/axis.sh
 

--- a/src/BeSimple/SoapClient/SoapClientBuilder.php
+++ b/src/BeSimple/SoapClient/SoapClientBuilder.php
@@ -209,7 +209,7 @@ class SoapClientBuilder extends AbstractSoapBuilder
     */
     public function withBase64Attachments()
     {
-        $this->options['attachment_type'] = Helper::ATTACHMENTS_TYPE_BASE64;
+        $this->soapOptions['attachment_type'] = Helper::ATTACHMENTS_TYPE_BASE64;
 
         return $this;
     }
@@ -221,7 +221,7 @@ class SoapClientBuilder extends AbstractSoapBuilder
      */
     public function withSwaAttachments()
     {
-        $this->options['attachment_type'] = Helper::ATTACHMENTS_TYPE_SWA;
+        $this->soapOptions['attachment_type'] = Helper::ATTACHMENTS_TYPE_SWA;
 
         return $this;
     }
@@ -233,7 +233,7 @@ class SoapClientBuilder extends AbstractSoapBuilder
      */
     public function withMtomAttachments()
     {
-        $this->options['attachment_type'] = Helper::ATTACHMENTS_TYPE_MTOM;
+        $this->soapOptions['attachment_type'] = Helper::ATTACHMENTS_TYPE_MTOM;
 
         return $this;
     }


### PR DESCRIPTION
Attachment type is set to wrong class property.
It should set `attachment_type` option to `soapOptions` class property, not to `options`.
Since `soapOptions` is passed to `BeSimple\SoapClient\SoapClient` constructor and later to `configureMime()` where it is checked for `attachment_type` option.

`options` class property does not do anything.
