### PR TITLE
x-m-l prefix is reserved

### DIFF
--- a/src/BeSimple/SoapCommon/Helper.php
+++ b/src/BeSimple/SoapCommon/Helper.php
@@ -144,7 +144,7 @@ class Helper
     /**
      * Describing Media Content of Binary Data in XML namespace prefix.
      */
-    const PFX_XMLMIME = 'xmlmime';
+    const PFX_XMLMIME = 'xmime';
 
     /**
      * XML Schema namespace prefix.


### PR DESCRIPTION
SoapUI XML validation fails (as well production client validators) because of namespace name "xmlmime" starts with letters x m l

`All other prefixes beginning with the three-letter sequence x, m, l, in any case combination, are reserved.`

Reference:
http://www.w3.org/TR/xml-names/#xmlReserved
