### PR TITLE
Use aliases in SoapClient Mime Filters

### DIFF
--- a/src/BeSimple/SoapClient/MimeFilter.php
+++ b/src/BeSimple/SoapClient/MimeFilter.php
@@ -16,9 +16,9 @@ use BeSimple\SoapCommon\Helper;
 use BeSimple\SoapCommon\Mime\MultiPart as MimeMultiPart;
 use BeSimple\SoapCommon\Mime\Parser as MimeParser;
 use BeSimple\SoapCommon\Mime\Part as MimePart;
-use BeSimple\SoapCommon\SoapRequest;
+use BeSimple\SoapCommon\SoapRequest as CommonSoapRequest;
 use BeSimple\SoapCommon\SoapRequestFilter;
-use BeSimple\SoapCommon\SoapResponse;
+use BeSimple\SoapCommon\SoapResponse as CommonSoapResponse;
 use BeSimple\SoapCommon\SoapResponseFilter;
 
 /**
@@ -60,7 +60,7 @@ class MimeFilter implements SoapRequestFilter, SoapResponseFilter
      *
      * @return void
      */
-    public function filterRequest(SoapRequest $request)
+    public function filterRequest(CommonSoapRequest $request)
     {
         // get attachments from request object
         $attachmentsToSend = $request->getAttachments();
@@ -103,7 +103,7 @@ class MimeFilter implements SoapRequestFilter, SoapResponseFilter
      *
      * @return void
      */
-    public function filterResponse(SoapResponse $response)
+    public function filterResponse(CommonSoapResponse $response)
     {
         // array to store attachments
         $attachmentsRecieved = array();

--- a/src/BeSimple/SoapClient/XmlMimeFilter.php
+++ b/src/BeSimple/SoapClient/XmlMimeFilter.php
@@ -14,7 +14,7 @@ namespace BeSimple\SoapClient;
 
 use BeSimple\SoapCommon\FilterHelper;
 use BeSimple\SoapCommon\Helper;
-use BeSimple\SoapCommon\SoapRequest;
+use BeSimple\SoapCommon\SoapRequest as CommonSoapRequest;
 use BeSimple\SoapCommon\SoapRequestFilter;
 
 /**
@@ -38,7 +38,7 @@ class XmlMimeFilter implements SoapRequestFilter
      *
      * @return void
      */
-    public function filterRequest(SoapRequest $request)
+    public function filterRequest(CommonSoapRequest $request)
     {
         // get \DOMDocument from SOAP request
         $dom = $request->getContentDocument();

--- a/src/BeSimple/SoapCommon/Mime/Parser.php
+++ b/src/BeSimple/SoapCommon/Mime/Parser.php
@@ -108,7 +108,9 @@ class Parser
                         }
                         $multipart->addPart($currentPart, $isMain);
                         $content = '';
-                    }
+                    } else {
+                        $content .= $line . "\r\n";                        
+                    } 
                 } else {
                     if ($hitFirstBoundary === false) {
                         if (trim($line) != '') {

--- a/src/BeSimple/SoapCommon/Tests/Fixtures/WS-I-MTOM-response-hyphen.txt
+++ b/src/BeSimple/SoapCommon/Tests/Fixtures/WS-I-MTOM-response-hyphen.txt
@@ -1,0 +1,25 @@
+POST http://131.107.72.15/Mtom/svc/service.svc/Soap12MtomUTF8 HTTP/1.1
+Content-Type: multipart/related; type="application/xop+xml";start="<http://tempuri.org/0>";boundary="uuid:0ca0e16e-feb1-426c-97d8-c4508ada5e82+id=7";start-info="application/soap+xml"
+Host: 131.107.72.15
+Content-Length: 1941
+Expect: 100-continue
+HTTP/1.1 100 Continue
+
+--uuid:0ca0e16e-feb1-426c-97d8-c4508ada5e82+id=7
+Content-ID: <http://tempuri.org/0>
+Content-Transfer-Encoding: 8bit
+Content-Type: application/xop+xml;charset=utf-8;type="application/soap+xml"
+
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"><s:Header><a:Action s:mustUnderstand="1">http://xmlsoap.org/echoBinaryAsString</a:Action><a:MessageID>urn:uuid:1bf061d6-d532-4b0c-930b-8b8202c38b8a</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><a:To s:mustUnderstand="1">http://131.107.72.15/Mtom/svc/service.svc/Soap12MtomUTF8</a:To></s:Header><s:Body><EchoBinaryAsString xmlns="http://xmlsoap.org/Ping"><array><xop:Include href="cid:http%3A%2F%2Ftempuri.org%2F1%2F632618206527087310" xmlns:xop="http://www.w3.org/2004/08/xop/include"/></array></EchoBinaryAsString></s:Body></s:Envelope>
+
+--uuid:0ca0e16e-feb1-426c-97d8-c4508ada5e82+id=7
+Content-ID: <http://tempuri.org/1/632618206527087310>
+Content-Transfer-Encoding: binary
+Content-Type: application/octet-stream
+
+Hello world.
+-this line starts with a hyphen!
+--This one starts with two hyphens.
+Hi Again.
+
+--uuid:0ca0e16e-feb1-426c-97d8-c4508ada5e82+id=7--

--- a/src/BeSimple/SoapCommon/Tests/Mime/ParserTest.php
+++ b/src/BeSimple/SoapCommon/Tests/Mime/ParserTest.php
@@ -124,6 +124,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $mp = Parser::parseMimeMessage($mimeMessage, $headers);
         $this->assertsForWsiMtomRequest($mp);
     }
+    
+    public function testParserWithHContentHyphens() {
+        $filename = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures/WS-I-MTOM-response-hyphen.txt';
+        $mimeMessage = file_get_contents($filename);
+
+        $mp = Parser::parseMimeMessage($mimeMessage);
+
+        $p1 = $mp->getPart('http://tempuri.org/1/632618206527087310');
+        $this->assertInstanceOf('BeSimple\SoapCommon\Mime\Part', $p1);
+        $this->assertEquals(96, strlen($p1->getContent()));
+    }
 
     /*
      * used in:


### PR DESCRIPTION
Fix naming conflicts by using aliases to import classes and namespaces.

Fixes BeSimple/BeSimpleSoap#89
