### PR TITLE
Symfony 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,52 +1,53 @@
 {
-    "name": "besimple/soap",
-    "type": "library",
-    "description": "Build and consume SOAP and WSDL based web services",
-    "keywords": ["soap"],
-    "homepage": "http://besim.pl",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Francis Besset",
-            "email": "francis.besset@gmail.com"
-        },
-        {
-            "name": "Christian Kerl",
-            "email": "christian-kerl@web.de"
-        },
-        {
-            "name": "Andreas Schamberger",
-            "email": "mail@andreass.net"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.0",
-        "ext-soap": "*",
-        "ext-curl": "*",
-        "ass/xmlsecurity": "~1.0",
-        "symfony/framework-bundle": "~2.6",
-        "symfony/twig-bundle": "~2.6",
-        "zendframework/zend-mime": "2.1.*"
-    },
-    "replace": {
-        "besimple/soap-bundle": "self.version",
-        "besimple/soap-client": "self.version",
-        "besimple/soap-common": "self.version",
-        "besimple/soap-server": "self.version",
-        "besimple/soap-wsdl":   "self.version"
-    },
-    "require-dev": {
-        "ext-mcrypt": "*",
-        "mikey179/vfsStream": "~1.0",
-        "symfony/filesystem": "~2.3",
-        "symfony/process": "~2.3"
-    },
-    "autoload": {
-        "psr-0": { "BeSimple\\": "src/" }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.3-dev"
-        }
-    }
+	"name" : "besimple/soap",
+	"type" : "library",
+	"description" : "Build and consume SOAP and WSDL based web services",
+	"keywords" : [
+		"soap"
+	],
+	"homepage" : "http://besim.pl",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Francis Besset",
+			"email" : "francis.besset@gmail.com"
+		}, {
+			"name" : "Christian Kerl",
+			"email" : "christian-kerl@web.de"
+		}, {
+			"name" : "Andreas Schamberger",
+			"email" : "mail@andreass.net"
+		}
+	],
+	"require" : {
+		"php" : ">=5.3.0",
+		"ext-soap" : "*",
+		"ext-curl" : "*",
+		"ass/xmlsecurity" : "~1.0",
+		"symfony/framework-bundle" : "^2.7 || ^3.0",
+		"symfony/twig-bundle" : "^2.7 || ^3.0",
+		"zendframework/zend-mime" : "2.1.*"
+	},
+	"replace" : {
+		"besimple/soap-bundle" : "self.version",
+		"besimple/soap-client" : "self.version",
+		"besimple/soap-common" : "self.version",
+		"besimple/soap-server" : "self.version",
+		"besimple/soap-wsdl" : "self.version"
+	},
+	"require-dev" : {
+		"ext-mcrypt" : "*",
+		"mikey179/vfsStream" : "~1.0",
+		"symfony/filesystem" : "~2.3",
+		"symfony/process" : "~2.3"
+	},
+	"autoload" : {
+		"psr-0" : {
+			"BeSimple\\" : "src/"
+		}
+	},
+	"extra" : {
+		"branch-alias" : {
+			"dev-master" : "0.3-dev"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,52 @@
 {
-	"name" : "besimple/soap",
-	"type" : "library",
-	"description" : "Build and consume SOAP and WSDL based web services",
-	"keywords" : [
-		"soap"
-	],
-	"homepage" : "http://besim.pl",
-	"license" : "MIT",
-	"authors" : [{
-			"name" : "Francis Besset",
-			"email" : "francis.besset@gmail.com"
-		}, {
-			"name" : "Christian Kerl",
-			"email" : "christian-kerl@web.de"
-		}, {
-			"name" : "Andreas Schamberger",
-			"email" : "mail@andreass.net"
-		}
-	],
-	"require" : {
-		"php" : ">=5.3.0",
-		"ext-soap" : "*",
-		"ext-curl" : "*",
-		"ass/xmlsecurity" : "~1.0",
-		"symfony/framework-bundle" : "^2.7 || ^3.0",
-		"symfony/twig-bundle" : "^2.7 || ^3.0",
-		"zendframework/zend-mime" : "2.1.*"
-	},
-	"replace" : {
-		"besimple/soap-bundle" : "self.version",
-		"besimple/soap-client" : "self.version",
-		"besimple/soap-common" : "self.version",
-		"besimple/soap-server" : "self.version",
-		"besimple/soap-wsdl" : "self.version"
-	},
-	"require-dev" : {
-		"ext-mcrypt" : "*",
-		"mikey179/vfsStream" : "~1.0",
-		"symfony/filesystem" : "~2.3",
-		"symfony/process" : "~2.3"
-	},
-	"autoload" : {
-		"psr-0" : {
-			"BeSimple\\" : "src/"
-		}
-	},
-	"extra" : {
-		"branch-alias" : {
-			"dev-master" : "0.3-dev"
-		}
-	}
+    "name": "besimple/soap",
+    "type": "library",
+    "description": "Build and consume SOAP and WSDL based web services",
+    "keywords": ["soap"],
+    "homepage": "http://besim.pl",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Francis Besset",
+            "email": "francis.besset@gmail.com"
+        },
+        {
+            "name": "Christian Kerl",
+            "email": "christian-kerl@web.de"
+        },
+        {
+            "name": "Andreas Schamberger",
+            "email": "mail@andreass.net"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "ext-soap": "*",
+        "ext-curl": "*",
+        "ass/xmlsecurity": "~1.0",
+        "symfony/framework-bundle": "^2.7 || ^3.0",
+        "symfony/twig-bundle": "^2.7 || ^3.0",
+        "zendframework/zend-mime": "2.1.*"
+    },
+    "replace": {
+        "besimple/soap-bundle": "self.version",
+        "besimple/soap-client": "self.version",
+        "besimple/soap-common": "self.version",
+        "besimple/soap-server": "self.version",
+        "besimple/soap-wsdl":   "self.version"
+    },
+    "require-dev": {
+        "ext-mcrypt": "*",
+        "mikey179/vfsStream": "~1.0",
+        "symfony/filesystem": "~2.3",
+        "symfony/process": "~2.3"
+    },
+    "autoload": {
+        "psr-0": { "BeSimple\\": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3-dev"
+        }
+    }
 }

--- a/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
+++ b/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
@@ -16,19 +16,20 @@ use BeSimple\SoapBundle\Handler\ExceptionHandler;
 use BeSimple\SoapBundle\Soap\SoapRequest;
 use BeSimple\SoapBundle\Soap\SoapResponse;
 use BeSimple\SoapServer\SoapServerBuilder;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Christian Kerl <christian-kerl@web.de>
  * @author Francis Besset <francis.besset@gmail.com>
  */
-class SoapWebServiceController extends ContainerAware
+class SoapWebServiceController extends Controller
 {
     /**
      * @var \SoapServer
@@ -58,13 +59,14 @@ class SoapWebServiceController extends ContainerAware
     /**
      * @return \BeSimple\SoapBundle\Soap\SoapResponse
      */
-    public function callAction($webservice)
+    public function callAction(Request $request, $webservice)
     {
         $webServiceContext   = $this->getWebServiceContext($webservice);
 
         $this->serviceBinder = $webServiceContext->getServiceBinder();
 
-        $this->soapRequest = SoapRequest::createFromHttpRequest($this->container->get('request'));
+        $this->soapRequest = SoapRequest::createFromHttpRequest($request);
+
         $this->soapServer  = $webServiceContext
             ->getServerBuilder()
             ->withSoapVersion11()
@@ -85,17 +87,16 @@ class SoapWebServiceController extends ContainerAware
     /**
      * @return Symfony\Component\HttpFoundation\Response
      */
-    public function definitionAction($webservice)
+    public function definitionAction(Request $request, $webservice)
     {
         $response = new Response($this->getWebServiceContext($webservice)->getWsdlFileContent(
             $this->container->get('router')->generate(
                 '_webservice_call',
                 array('webservice' => $webservice),
-                true
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
         ));
 
-        $request = $this->container->get('request');
         $query = $request->query;
         if ($query->has('wsdl') || $query->has('WSDL')) {
             $request->setRequestFormat('wsdl');

--- a/src/BeSimple/SoapBundle/Converter/TypeRepository.php
+++ b/src/BeSimple/SoapBundle/Converter/TypeRepository.php
@@ -10,7 +10,6 @@
 
 namespace BeSimple\SoapBundle\Converter;
 
-use BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition;
 use BeSimple\SoapBundle\Util\Assert;
 
 /**
@@ -44,23 +43,5 @@ class TypeRepository
     public function getXmlTypeMapping($phpType)
     {
         return isset($this->defaultTypeMap[$phpType]) ? $this->defaultTypeMap[$phpType] : null;
-    }
-
-    public function fixTypeInformation(ServiceDefinition $definition)
-    {
-        foreach($definition->getAllTypes() as $type) {
-            $phpType = $type->getPhpType();
-            $xmlType = $type->getXmlType();
-
-            if (null === $phpType) {
-                throw new \InvalidArgumentException();
-            }
-
-            if (null === $xmlType) {
-                $xmlType = $this->getXmlTypeMapping($phpType);
-            }
-
-            $type->setXmlType($xmlType);
-        }
     }
 }

--- a/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
+++ b/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
@@ -14,7 +14,7 @@ namespace BeSimple\SoapBundle\Handler;
 
 use BeSimple\SoapServer\Exception\ReceiverSoapFault;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 
 /**
  * @author Francis Besset <francis.besset@gmail.com>

--- a/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
@@ -4,15 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_webservice_call" pattern="/{webservice}">
+    <route id="_webservice_call" path="/{webservice}" methods="POST">
         <default key="_controller">BeSimpleSoapBundle:SoapWebService:Call</default>
         <default key="_format">xml</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="_webservice_definition" pattern="/{webservice}">
+    <route id="_webservice_definition" path="/{webservice}" methods="GET">
         <default key="_controller">BeSimpleSoapBundle:SoapWebService:Definition</default>
         <default key="_format">xml</default>
-        <requirement key="_method">GET</requirement>
     </route>
 </routes>

--- a/src/BeSimple/SoapBundle/ServiceBinding/ServiceBinder.php
+++ b/src/BeSimple/SoapBundle/ServiceBinding/ServiceBinder.php
@@ -19,7 +19,7 @@ use BeSimple\SoapBundle\Soap\SoapHeader;
 class ServiceBinder
 {
     /**
-     * @var \BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition
+     * @var \BeSimple\SoapBundle\ServiceDefinition\Definition
      */
     private $definition;
 

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -50,7 +50,7 @@ class AnnotationClassLoader extends Loader
      * @param string $class A class name
      * @param string $type  The resource type
      *
-     * @return \BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition A ServiceDefinition instance
+     * @return \BeSimple\SoapBundle\ServiceDefinition\Definition A Definition instance
      *
      * @throws \InvalidArgumentException When route can't be parsed
      */

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationFileLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationFileLoader.php
@@ -12,7 +12,7 @@
 
 namespace BeSimple\SoapBundle\ServiceDefinition\Loader;
 
-use BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition;
+use BeSimple\SoapBundle\ServiceDefinition\Definition;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\FileLoader;
@@ -52,7 +52,7 @@ class AnnotationFileLoader extends FileLoader
      * @param string $file A PHP file path
      * @param string $type The resource type
      *
-     * @return ServiceDefinition A ServiceDefinition instance
+     * @return Definition A Definition instance
      *
      * @throws \InvalidArgumentException When the file does not exist
      */

--- a/src/BeSimple/SoapBundle/WebServiceContext.php
+++ b/src/BeSimple/SoapBundle/WebServiceContext.php
@@ -44,7 +44,7 @@ class WebServiceContext
         if (null === $this->serviceDefinition) {
             $cache = new ConfigCache(sprintf('%s/%s.definition.php', $this->options['cache_dir'], $this->options['name']), $this->options['debug']);
             if ($cache->isFresh()) {
-                $this->serviceDefinition = include (string) $cache;
+                $this->serviceDefinition = include $cache->getPath();
             } else {
                 if (!$this->loader->supports($this->options['resource'], $this->options['resource_type'])) {
                     throw new \LogicException(sprintf('Cannot load "%s" (%s)', $this->options['resource'], $this->options['resource_type']));
@@ -71,7 +71,7 @@ class WebServiceContext
         $file      = sprintf ('%s/%s.%s.wsdl', $this->options['cache_dir'], $this->options['name'], md5($endpoint));
         $cache = new ConfigCache($file, $this->options['debug']);
 
-        if(!$cache->isFresh()) {
+        if (!$cache->isFresh()) {
             $definition = $this->getServiceDefinition();
 
             if ($endpoint) {
@@ -82,7 +82,7 @@ class WebServiceContext
             $cache->write($dumper->dump());
         }
 
-        return (string) $cache;
+        return $cache->getPath();
     }
 
     public function getServiceBinder()


### PR DESCRIPTION
This PR allow the usage of the bundle with Symfony 3.x and remove dead and buggy code (fixTypeInformation in TypeRepository.php is not used since ServiceDefinition have been renamed Definition).

Important: This commit break the compatibility with Symfony 2.7.x or lower.