### PR TITLE
Add a way to protect a service by WS-Security Authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,52 +1,53 @@
 {
-    "name": "besimple/soap",
-    "type": "library",
-    "description": "Build and consume SOAP and WSDL based web services",
-    "keywords": ["soap"],
-    "homepage": "http://besim.pl",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Francis Besset",
-            "email": "francis.besset@gmail.com"
-        },
-        {
-            "name": "Christian Kerl",
-            "email": "christian-kerl@web.de"
-        },
-        {
-            "name": "Andreas Schamberger",
-            "email": "mail@andreass.net"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.0",
-        "ext-soap": "*",
-        "ext-curl": "*",
-        "ass/xmlsecurity": "~1.0",
-        "symfony/framework-bundle": "~2.6",
-        "symfony/twig-bundle": "~2.6",
-        "zendframework/zend-mime": "2.1.*"
-    },
-    "replace": {
-        "besimple/soap-bundle": "self.version",
-        "besimple/soap-client": "self.version",
-        "besimple/soap-common": "self.version",
-        "besimple/soap-server": "self.version",
-        "besimple/soap-wsdl":   "self.version"
-    },
-    "require-dev": {
-        "ext-mcrypt": "*",
-        "mikey179/vfsStream": "~1.0",
-        "symfony/filesystem": "~2.3",
-        "symfony/process": "~2.3"
-    },
-    "autoload": {
-        "psr-0": { "BeSimple\\": "src/" }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.3-dev"
-        }
-    }
+	"name" : "besimple/soap",
+	"type" : "library",
+	"description" : "Build and consume SOAP and WSDL based web services",
+	"keywords" : [
+		"soap"
+	],
+	"homepage" : "http://besim.pl",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Francis Besset",
+			"email" : "francis.besset@gmail.com"
+		}, {
+			"name" : "Christian Kerl",
+			"email" : "christian-kerl@web.de"
+		}, {
+			"name" : "Andreas Schamberger",
+			"email" : "mail@andreass.net"
+		}
+	],
+	"require" : {
+		"php" : ">=5.3.0",
+		"ext-soap" : "*",
+		"ext-curl" : "*",
+		"ass/xmlsecurity" : "~1.0",
+		"symfony/framework-bundle" : "^2.7 || ^3.0",
+		"symfony/twig-bundle" : "^2.7 || ^3.0",
+		"zendframework/zend-mime" : "2.1.*"
+	},
+	"replace" : {
+		"besimple/soap-bundle" : "self.version",
+		"besimple/soap-client" : "self.version",
+		"besimple/soap-common" : "self.version",
+		"besimple/soap-server" : "self.version",
+		"besimple/soap-wsdl" : "self.version"
+	},
+	"require-dev" : {
+		"ext-mcrypt" : "*",
+		"mikey179/vfsStream" : "~1.0",
+		"symfony/filesystem" : "~2.3",
+		"symfony/process" : "~2.3"
+	},
+	"autoload" : {
+		"psr-0" : {
+			"BeSimple\\" : "src/"
+		}
+	},
+	"extra" : {
+		"branch-alias" : {
+			"dev-master" : "0.3-dev"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "ext-soap": "*",
         "ext-curl": "*",
         "ass/xmlsecurity": "~1.0",
-        "symfony/framework-bundle": "^2.7 || ^3.0",
-        "symfony/twig-bundle": "^2.7 || ^3.0",
+        "symfony/framework-bundle": "^3.0 || ^4.0",
+        "symfony/twig-bundle": "^3.0 || ^4.0",
         "zendframework/zend-mime": "2.1.*"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,52 @@
 {
-	"name" : "besimple/soap",
-	"type" : "library",
-	"description" : "Build and consume SOAP and WSDL based web services",
-	"keywords" : [
-		"soap"
-	],
-	"homepage" : "http://besim.pl",
-	"license" : "MIT",
-	"authors" : [{
-			"name" : "Francis Besset",
-			"email" : "francis.besset@gmail.com"
-		}, {
-			"name" : "Christian Kerl",
-			"email" : "christian-kerl@web.de"
-		}, {
-			"name" : "Andreas Schamberger",
-			"email" : "mail@andreass.net"
-		}
-	],
-	"require" : {
-		"php" : ">=5.3.0",
-		"ext-soap" : "*",
-		"ext-curl" : "*",
-		"ass/xmlsecurity" : "~1.0",
-		"symfony/framework-bundle" : "^2.7 || ^3.0",
-		"symfony/twig-bundle" : "^2.7 || ^3.0",
-		"zendframework/zend-mime" : "2.1.*"
-	},
-	"replace" : {
-		"besimple/soap-bundle" : "self.version",
-		"besimple/soap-client" : "self.version",
-		"besimple/soap-common" : "self.version",
-		"besimple/soap-server" : "self.version",
-		"besimple/soap-wsdl" : "self.version"
-	},
-	"require-dev" : {
-		"ext-mcrypt" : "*",
-		"mikey179/vfsStream" : "~1.0",
-		"symfony/filesystem" : "~2.3",
-		"symfony/process" : "~2.3"
-	},
-	"autoload" : {
-		"psr-0" : {
-			"BeSimple\\" : "src/"
-		}
-	},
-	"extra" : {
-		"branch-alias" : {
-			"dev-master" : "0.3-dev"
-		}
-	}
+    "name": "besimple/soap",
+    "type": "library",
+    "description": "Build and consume SOAP and WSDL based web services",
+    "keywords": ["soap"],
+    "homepage": "http://besim.pl",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Francis Besset",
+            "email": "francis.besset@gmail.com"
+        },
+        {
+            "name": "Christian Kerl",
+            "email": "christian-kerl@web.de"
+        },
+        {
+            "name": "Andreas Schamberger",
+            "email": "mail@andreass.net"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "ext-soap": "*",
+        "ext-curl": "*",
+        "ass/xmlsecurity": "~1.0",
+        "symfony/framework-bundle": "^2.7 || ^3.0",
+        "symfony/twig-bundle": "^2.7 || ^3.0",
+        "zendframework/zend-mime": "2.1.*"
+    },
+    "replace": {
+        "besimple/soap-bundle": "self.version",
+        "besimple/soap-client": "self.version",
+        "besimple/soap-common": "self.version",
+        "besimple/soap-server": "self.version",
+        "besimple/soap-wsdl":   "self.version"
+    },
+    "require-dev": {
+        "ext-mcrypt": "*",
+        "mikey179/vfsStream": "~1.0",
+        "symfony/filesystem": "~2.3",
+        "symfony/process": "~2.3"
+    },
+    "autoload": {
+        "psr-0": { "BeSimple\\": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3-dev"
+        }
+    }
 }

--- a/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
+++ b/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
@@ -122,7 +122,7 @@ class SoapWebServiceController extends AbstractController
             throw new \LogicException(sprintf('The parameter "%s" is required in Request::$query parameter bag to generate the SoapFault.', '_besimple_soap_webservice'), null, $e);
         }
 
-        $view = 'TwigBundle:Exception:'.($this->container->get('kernel')->isDebug() ? 'exception' : 'error').'.txt.twig';
+        $view = '@Twig/Exception/'.($this->container->get('kernel')->isDebug() ? 'exception' : 'error').'.txt.twig';
         $code = $exception->getStatusCode();
         $details = $this->container->get('twig')->render($view, array(
             'status_code' => $code,

--- a/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
+++ b/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
@@ -16,19 +16,20 @@ use BeSimple\SoapBundle\Handler\ExceptionHandler;
 use BeSimple\SoapBundle\Soap\SoapRequest;
 use BeSimple\SoapBundle\Soap\SoapResponse;
 use BeSimple\SoapServer\SoapServerBuilder;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Christian Kerl <christian-kerl@web.de>
  * @author Francis Besset <francis.besset@gmail.com>
  */
-class SoapWebServiceController extends ContainerAware
+class SoapWebServiceController extends Controller
 {
     /**
      * @var \SoapServer
@@ -58,13 +59,14 @@ class SoapWebServiceController extends ContainerAware
     /**
      * @return \BeSimple\SoapBundle\Soap\SoapResponse
      */
-    public function callAction($webservice)
+    public function callAction(Request $request, $webservice)
     {
         $webServiceContext   = $this->getWebServiceContext($webservice);
 
         $this->serviceBinder = $webServiceContext->getServiceBinder();
 
-        $this->soapRequest = SoapRequest::createFromHttpRequest($this->container->get('request'));
+        $this->soapRequest = SoapRequest::createFromHttpRequest($request);
+
         $this->soapServer  = $webServiceContext
             ->getServerBuilder()
             ->withSoapVersion11()
@@ -85,17 +87,16 @@ class SoapWebServiceController extends ContainerAware
     /**
      * @return Symfony\Component\HttpFoundation\Response
      */
-    public function definitionAction($webservice)
+    public function definitionAction(Request $request, $webservice)
     {
         $response = new Response($this->getWebServiceContext($webservice)->getWsdlFileContent(
             $this->container->get('router')->generate(
                 '_webservice_call',
                 array('webservice' => $webservice),
-                true
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
         ));
 
-        $request = $this->container->get('request');
         $query = $request->query;
         if ($query->has('wsdl') || $query->has('WSDL')) {
             $request->setRequestFormat('wsdl');

--- a/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
+++ b/src/BeSimple/SoapBundle/Controller/SoapWebServiceController.php
@@ -16,10 +16,10 @@ use BeSimple\SoapBundle\Handler\ExceptionHandler;
 use BeSimple\SoapBundle\Soap\SoapRequest;
 use BeSimple\SoapBundle\Soap\SoapResponse;
 use BeSimple\SoapServer\SoapServerBuilder;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @author Christian Kerl <christian-kerl@web.de>
  * @author Francis Besset <francis.besset@gmail.com>
  */
-class SoapWebServiceController extends Controller
+class SoapWebServiceController extends AbstractController
 {
     /**
      * @var \SoapServer
@@ -124,7 +124,7 @@ class SoapWebServiceController extends Controller
 
         $view = 'TwigBundle:Exception:'.($this->container->get('kernel')->isDebug() ? 'exception' : 'error').'.txt.twig';
         $code = $exception->getStatusCode();
-        $details = $this->container->get('templating')->render($view, array(
+        $details = $this->container->get('twig')->render($view, array(
             'status_code' => $code,
             'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
             'exception'   => $exception,

--- a/src/BeSimple/SoapBundle/Converter/TypeRepository.php
+++ b/src/BeSimple/SoapBundle/Converter/TypeRepository.php
@@ -10,7 +10,6 @@
 
 namespace BeSimple\SoapBundle\Converter;
 
-use BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition;
 use BeSimple\SoapBundle\Util\Assert;
 
 /**
@@ -44,23 +43,5 @@ class TypeRepository
     public function getXmlTypeMapping($phpType)
     {
         return isset($this->defaultTypeMap[$phpType]) ? $this->defaultTypeMap[$phpType] : null;
-    }
-
-    public function fixTypeInformation(ServiceDefinition $definition)
-    {
-        foreach($definition->getAllTypes() as $type) {
-            $phpType = $type->getPhpType();
-            $xmlType = $type->getXmlType();
-
-            if (null === $phpType) {
-                throw new \InvalidArgumentException();
-            }
-
-            if (null === $xmlType) {
-                $xmlType = $this->getXmlTypeMapping($phpType);
-            }
-
-            $type->setXmlType($xmlType);
-        }
     }
 }

--- a/src/BeSimple/SoapBundle/DependencyInjection/BeSimpleSoapExtension.php
+++ b/src/BeSimple/SoapBundle/DependencyInjection/BeSimpleSoapExtension.php
@@ -17,11 +17,12 @@ use BeSimple\SoapCommon\Cache;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use BeSimple\SoapCommon\WsSecurityFilterClientServer;
+use BeSimple\SoapBundle\Controller\SoapWebServiceController;
 
 /**
  * BeSimpleSoapExtension.
@@ -47,10 +48,9 @@ class BeSimpleSoapExtension extends Extension
         $loader->load('converters.xml');
         $loader->load('webservice.xml');
 
-        $processor     = new Processor();
         $configuration = new Configuration();
 
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         $this->registerCacheConfiguration($config['cache'], $container, $loader);
 
@@ -84,7 +84,7 @@ class BeSimpleSoapExtension extends Extension
         $loader->load('client.xml');
 
         foreach ($config as $client => $options) {
-            $definition = new DefinitionDecorator('besimple.soap.client.builder');
+            $definition = new ChildDefinition('besimple.soap.client.builder');
             $container->setDefinition(sprintf('besimple.soap.client.builder.%s', $client), $definition);
 
             $definition->replaceArgument(0, $options['wsdl']);
@@ -131,7 +131,7 @@ class BeSimpleSoapExtension extends Extension
 
     private function createClientClassmap($client, array $classmap, ContainerBuilder $container)
     {
-        $definition = new DefinitionDecorator('besimple.soap.classmap');
+        $definition = new ChildDefinition('besimple.soap.classmap');
         $container->setDefinition(sprintf('besimple.soap.classmap.%s', $client), $definition);
 
         if (!empty($classmap)) {
@@ -145,7 +145,7 @@ class BeSimpleSoapExtension extends Extension
 
     private function createClient($client, ContainerBuilder $container)
     {
-        $definition = new DefinitionDecorator('besimple.soap.client');
+        $definition = new ChildDefinition('besimple.soap.client');
         $container->setDefinition(sprintf('besimple.soap.client.%s', $client), $definition);
 
         $definition->setFactory(array(
@@ -160,7 +160,9 @@ class BeSimpleSoapExtension extends Extension
         unset($config['binding']);
 
         $contextId  = 'besimple.soap.context.'.$config['name'];
-        $definition = new DefinitionDecorator('besimple.soap.context.'.$bindingSuffix);
+        $definition = new ChildDefinition('besimple.soap.context.'.$bindingSuffix);
+        $definition->setPublic(true);
+
         $container->setDefinition($contextId, $definition);
 
         if (isset($config['cache_type'])) {

--- a/src/BeSimple/SoapBundle/DependencyInjection/BeSimpleSoapExtension.php
+++ b/src/BeSimple/SoapBundle/DependencyInjection/BeSimpleSoapExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use BeSimple\SoapCommon\WsSecurityFilterClientServer;
 
 /**
  * BeSimpleSoapExtension.
@@ -166,6 +167,10 @@ class BeSimpleSoapExtension extends Extension
             $config['cache_type'] = $this->getCacheType($config['cache_type']);
         }
 
+        if (isset($config['wsse'])) {
+            $config['wsse']['password_type'] = $this->getPasswordType($config['wsse']['password_type']);
+        }
+
         $options = $container
             ->getDefinition('besimple.soap.context.'.$bindingSuffix)
             ->getArgument(2);
@@ -187,6 +192,17 @@ class BeSimpleSoapExtension extends Extension
 
             case 'disk_memory':
                 return Cache::TYPE_DISK_MEMORY;
+        }
+    }
+
+    private function getPasswordType($type)
+    {
+        switch ($type) {
+            case 'PasswordText':
+                return WsSecurityFilterClientServer::PASSWORD_TYPE_TEXT;
+
+            case 'PasswordDigest':
+                return WsSecurityFilterClientServer::PASSWORD_TYPE_DIGEST;
         }
     }
 }

--- a/src/BeSimple/SoapBundle/DependencyInjection/Configuration.php
+++ b/src/BeSimple/SoapBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration
 {
     private $cacheTypes = array('none', 'disk', 'memory', 'disk_memory');
     private $proxyAuth = array('basic', 'ntlm');
+    private $passwordTypes = array('PasswordText', 'PasswordDigest');
 
     /**
      * Generates the configuration tree.
@@ -143,6 +144,19 @@ class Configuration
                                 ->validate()
                                     ->ifNotInArray($this->cacheTypes)
                                     ->thenInvalid(sprintf('The cache type has to be either %s', implode(', ', $this->cacheTypes)))
+                                ->end()
+                            ->end()
+                            ->arrayNode('wsse')
+                                ->children()
+                                    ->scalarNode('password_type')
+                                        ->defaultValue($this->passwordTypes[0])
+                                        ->validate()
+                                            ->ifNotInArray($this->passwordTypes)
+                                            ->thenInvalid(sprintf('The password type has to be either: %s', implode(', ', $this->passwordTypes)))
+                                        ->end()
+                                    ->end()
+                                    ->scalarNode('username')->defaultNull()->end()
+                                    ->scalarNode('password')->defaultNull()->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/BeSimple/SoapBundle/EventListener/SoapExceptionListener.php
+++ b/src/BeSimple/SoapBundle/EventListener/SoapExceptionListener.php
@@ -13,15 +13,15 @@
 namespace BeSimple\SoapBundle\EventListener;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * @author Francis Besset <francis.besset@gmail.com>
  */
-class SoapExceptionListener extends ExceptionListener
+class SoapExceptionListener extends ErrorListener
 {
     /**
      * @var ContainerInterface
@@ -44,7 +44,7 @@ class SoapExceptionListener extends ExceptionListener
         $this->container = $container;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onSoapKernelException(ExceptionEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -69,7 +69,7 @@ class SoapExceptionListener extends ExceptionListener
         // hack to retrieve the current WebService name in the controller
         $request->query->set('_besimple_soap_webservice', $webservice);
 
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         if ($exception instanceof \SoapFault) {
             $request->query->set('_besimple_soap_fault', $exception);
         }
@@ -77,11 +77,12 @@ class SoapExceptionListener extends ExceptionListener
         parent::onKernelException($event);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
-        return array(
-            // Must be called before ExceptionListener of HttpKernel component
-            KernelEvents::EXCEPTION => array('onKernelException', -64),
-        );
+        return [
+            KernelEvents::EXCEPTION => [
+                ['onSoapKernelException', -64],
+            ],
+        ];
     }
 }

--- a/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
+++ b/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
@@ -14,7 +14,7 @@ namespace BeSimple\SoapBundle\Handler;
 
 use BeSimple\SoapServer\Exception\ReceiverSoapFault;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 
 /**
  * @author Francis Besset <francis.besset@gmail.com>

--- a/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
+++ b/src/BeSimple/SoapBundle/Handler/ExceptionHandler.php
@@ -14,7 +14,7 @@ namespace BeSimple\SoapBundle\Handler;
 
 use BeSimple\SoapServer\Exception\ReceiverSoapFault;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 /**
  * @author Francis Besset <francis.besset@gmail.com>

--- a/src/BeSimple/SoapBundle/Resources/config/converters.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/converters.xml
@@ -8,6 +8,7 @@
         <parameter key="besimple.soap.converter.collection.class">BeSimple\SoapCommon\Converter\TypeConverterCollection</parameter>
         <parameter key="besimple.soap.converter.date_time.class">BeSimple\SoapCommon\Converter\DateTimeTypeConverter</parameter>
         <parameter key="besimple.soap.converter.date.class">BeSimple\SoapCommon\Converter\DateTypeConverter</parameter>
+        <parameter key="besimple.soap.converter.time.class">BeSimple\SoapCommon\Converter\TimeTypeConverter</parameter>
     </parameters>
 
     <services>
@@ -18,6 +19,10 @@
         </service>
 
         <service id="besimple.soap.converter.date" class="%besimple.soap.converter.date.class%" public="false">
+            <tag name="besimple.soap.converter" />
+        </service>
+        
+        <service id="besimple.soap.converter.time" class="%besimple.soap.converter.time.class%" public="false">
             <tag name="besimple.soap.converter" />
         </service>
     </services>

--- a/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
@@ -4,15 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_webservice_call" pattern="/{webservice}">
+    <route id="_webservice_call" path="/{webservice}" methods="POST">
         <default key="_controller">BeSimpleSoapBundle:SoapWebService:Call</default>
         <default key="_format">xml</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="_webservice_definition" pattern="/{webservice}">
+    <route id="_webservice_definition" path="/{webservice}" methods="GET">
         <default key="_controller">BeSimpleSoapBundle:SoapWebService:Definition</default>
         <default key="_format">xml</default>
-        <requirement key="_method">GET</requirement>
     </route>
 </routes>

--- a/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/routing/webservicecontroller.xml
@@ -5,12 +5,12 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="_webservice_call" path="/{webservice}" methods="POST">
-        <default key="_controller">BeSimpleSoapBundle:SoapWebService:Call</default>
+        <default key="_controller">BeSimple\SoapBundle\Controller\SoapWebServiceController::CallAction</default>
         <default key="_format">xml</default>
     </route>
 
     <route id="_webservice_definition" path="/{webservice}" methods="GET">
-        <default key="_controller">BeSimpleSoapBundle:SoapWebService:Definition</default>
+        <default key="_controller">BeSimple\SoapBundle\Controller\SoapWebServiceController::DefinitionAction</default>
         <default key="_format">xml</default>
     </route>
 </routes>

--- a/src/BeSimple/SoapBundle/Resources/config/webservice.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/webservice.xml
@@ -19,6 +19,14 @@
     </parameters>
 
     <services>
+    
+        <prototype namespace="BeSimple\SoapBundle\Controller\" resource="../../Controller">
+            <tag name="controller.service_arguments"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"></argument>
+            </call>
+        </prototype>
+    
         <service id="besimple.soap.response" class="%besimple.soap.response.class%" />
 
         <service id="besimple.soap.response.listener" class="%besimple.soap.response.listener.class%">

--- a/src/BeSimple/SoapBundle/Resources/config/webservice.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/webservice.xml
@@ -27,7 +27,7 @@
             </call>
         </prototype>
     
-        <service id="besimple.soap.response" class="%besimple.soap.response.class%" />
+        <service id="besimple.soap.response" class="%besimple.soap.response.class%" public="true"/>
 
         <service id="besimple.soap.response.listener" class="%besimple.soap.response.listener.class%">
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" />

--- a/src/BeSimple/SoapBundle/Resources/config/webservice.xml
+++ b/src/BeSimple/SoapBundle/Resources/config/webservice.xml
@@ -96,6 +96,10 @@
                 <argument>dateTime</argument>
                 <argument>xsd:dateTime</argument>
             </call>
+            <call method="addType">
+                <argument>time</argument>
+                <argument>xsd:time</argument>
+            </call>
         </service>
     </services>
 

--- a/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralRequestMessageBinder.php
+++ b/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralRequestMessageBinder.php
@@ -81,7 +81,14 @@ class RpcLiteralRequestMessageBinder implements MessageBinderInterface
 
                 $message = $array;
             } else {
-                $message = $this->checkComplexType($phpType, $message);
+                if (is_array($message)) {
+                    foreach ($message as $complexType) {
+                        $array[] = $this->checkComplexType($phpType, $complexType);
+                    }
+                    $message = $array;
+                } else {
+                    $message = $this->checkComplexType($phpType, $message);
+                }
             }
         } elseif ($isArray) {
             if (isset($message->item)) {

--- a/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralResponseMessageBinder.php
+++ b/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralResponseMessageBinder.php
@@ -68,7 +68,14 @@ class RpcLiteralResponseMessageBinder implements MessageBinderInterface
 
                 $message = $array;
             } else {
-                $message = $this->checkComplexType($phpType, $message);
+                if (is_array($message)) {
+                    foreach ($message as $complexType) {
+                        $array[] = $this->checkComplexType($phpType, $complexType);
+                    }
+                    $message = $array;
+                } else {
+                    $message = $this->checkComplexType($phpType, $message);
+                }
             }
         }
 

--- a/src/BeSimple/SoapBundle/ServiceBinding/ServiceBinder.php
+++ b/src/BeSimple/SoapBundle/ServiceBinding/ServiceBinder.php
@@ -19,7 +19,7 @@ use BeSimple\SoapBundle\Soap\SoapHeader;
 class ServiceBinder
 {
     /**
-     * @var \BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition
+     * @var \BeSimple\SoapBundle\ServiceDefinition\Definition
      */
     private $definition;
 

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Annotation/ComplexType.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Annotation/ComplexType.php
@@ -18,6 +18,8 @@ class ComplexType extends Configuration
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -47,6 +49,23 @@ class ComplexType extends Configuration
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 
     public function getAliasName()

--- a/src/BeSimple/SoapBundle/ServiceDefinition/ComplexType.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/ComplexType.php
@@ -20,6 +20,8 @@ class ComplexType
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -49,5 +51,25 @@ class ComplexType
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 }

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -155,7 +155,7 @@ class AnnotationClassLoader extends Loader
             $loaded = $complexTypeResolver->load($phpType);
             $complexType = new ComplexType($phpType, isset($loaded['alias']) ? $loaded['alias'] : $phpType);
             foreach ($loaded['properties'] as $name => $property) {
-                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable());
+                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable(), $property->getMinOccurs(), $property->getMaxOccurs());
             }
 
             $this->typeRepository->addComplexType($complexType);

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -50,7 +50,7 @@ class AnnotationClassLoader extends Loader
      * @param string $class A class name
      * @param string $type  The resource type
      *
-     * @return \BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition A ServiceDefinition instance
+     * @return \BeSimple\SoapBundle\ServiceDefinition\Definition A Definition instance
      *
      * @throws \InvalidArgumentException When route can't be parsed
      */

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
@@ -58,6 +58,8 @@ class AnnotationComplexTypeLoader extends AnnotationClassLoader
                 $propertyComplexType = new ComplexType();
                 $propertyComplexType->setValue($complexType->getValue());
                 $propertyComplexType->setNillable($complexType->isNillable());
+                $propertyComplexType->setMinOccurs($complexType->getMinOccurs());
+                $propertyComplexType->setMaxOccurs($complexType->getMaxOccurs());
                 $propertyComplexType->setName($property->getName());
                 $annotations['properties']->add($propertyComplexType);
             }

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationFileLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationFileLoader.php
@@ -12,7 +12,7 @@
 
 namespace BeSimple\SoapBundle\ServiceDefinition\Loader;
 
-use BeSimple\SoapBundle\ServiceDefinition\ServiceDefinition;
+use BeSimple\SoapBundle\ServiceDefinition\Definition;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\FileLoader;
@@ -52,7 +52,7 @@ class AnnotationFileLoader extends FileLoader
      * @param string $file A PHP file path
      * @param string $type The resource type
      *
-     * @return ServiceDefinition A ServiceDefinition instance
+     * @return Definition A Definition instance
      *
      * @throws \InvalidArgumentException When the file does not exist
      */

--- a/src/BeSimple/SoapBundle/WebServiceContext.php
+++ b/src/BeSimple/SoapBundle/WebServiceContext.php
@@ -44,7 +44,7 @@ class WebServiceContext
         if (null === $this->serviceDefinition) {
             $cache = new ConfigCache(sprintf('%s/%s.definition.php', $this->options['cache_dir'], $this->options['name']), $this->options['debug']);
             if ($cache->isFresh()) {
-                $this->serviceDefinition = include (string) $cache;
+                $this->serviceDefinition = include $cache->getPath();
             } else {
                 if (!$this->loader->supports($this->options['resource'], $this->options['resource_type'])) {
                     throw new \LogicException(sprintf('Cannot load "%s" (%s)', $this->options['resource'], $this->options['resource_type']));
@@ -71,7 +71,7 @@ class WebServiceContext
         $file      = sprintf ('%s/%s.%s.wsdl', $this->options['cache_dir'], $this->options['name'], md5($endpoint));
         $cache = new ConfigCache($file, $this->options['debug']);
 
-        if(!$cache->isFresh()) {
+        if (!$cache->isFresh()) {
             $definition = $this->getServiceDefinition();
 
             if ($endpoint) {
@@ -82,7 +82,7 @@ class WebServiceContext
             $cache->write($dumper->dump());
         }
 
-        return (string) $cache;
+        return $cache->getPath();
     }
 
     public function getServiceBinder()

--- a/src/BeSimple/SoapBundle/WebServiceContext.php
+++ b/src/BeSimple/SoapBundle/WebServiceContext.php
@@ -111,6 +111,9 @@ class WebServiceContext
             if (null !== $this->options['cache_type']) {
                 $this->serverBuilder->withWsdlCache($this->options['cache_type']);
             }
+            if (isset($this->options['wsse'])) {
+                $this->serverBuilder->withWsse($this->options['wsse']);
+            }
         }
 
         return $this->serverBuilder;

--- a/src/BeSimple/SoapClient/WsSecurityFilter.php
+++ b/src/BeSimple/SoapClient/WsSecurityFilter.php
@@ -36,16 +36,6 @@ use BeSimple\SoapCommon\WsSecurityFilterClientServer;
 class WsSecurityFilter extends WsSecurityFilterClientServer implements SoapRequestFilter, SoapResponseFilter
 {
     /**
-     * (UT 3.1) Password type: plain text.
-     */
-    const PASSWORD_TYPE_TEXT = 0;
-
-    /**
-     * (UT 3.1) Password type: digest.
-     */
-    const PASSWORD_TYPE_DIGEST = 1;
-
-    /**
      * (UT 3.1) Password.
      *
      * @var string

--- a/src/BeSimple/SoapCommon/Converter/TimeTypeConverter.php
+++ b/src/BeSimple/SoapCommon/Converter/TimeTypeConverter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the BeSimpleSoapCommon.
+ *
+ * (c) Christian Kerl <christian-kerl@web.de>
+ * (c) Francis Besset <francis.besset@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace BeSimple\SoapCommon\Converter;
+
+/**
+ * @author Francis Besset <francis.besset@gmail.com>
+ */
+class TimeTypeConverter implements TypeConverterInterface
+{
+    public function getTypeNamespace()
+    {
+        return 'http://www.w3.org/2001/XMLSchema';
+    }
+
+    public function getTypeName()
+    {
+        return 'time';
+    }
+
+    public function convertXmlToPhp($data)
+    {
+        $doc = new \DOMDocument();
+        $doc->loadXML($data);
+
+        if ('' === $doc->textContent) {
+            return null;
+        }
+
+        return new \DateTime($doc->textContent);
+    }
+
+    public function convertPhpToXml($data)
+    {
+        return sprintf('<%1$s>%2$s</%1$s>', $this->getTypeName(), $data->format('H:i:s'));
+    }
+}
+

--- a/src/BeSimple/SoapCommon/Definition/Message.php
+++ b/src/BeSimple/SoapCommon/Definition/Message.php
@@ -48,13 +48,13 @@ class Message
         return 0 === count($this->parts) ? true : false;
     }
 
-    public function add($name, $phpType, $nillable = false)
+    public function add($name, $phpType, $nillable = false, $minOccurs = null, $maxOccurs = null)
     {
         if ($phpType instanceof TypeInterface) {
             $phpType = $phpType->getPhpType();
         }
 
-        $this->parts[$name] = new Part($name, $phpType, $nillable);
+        $this->parts[$name] = new Part($name, $phpType, $nillable, $minOccurs, $maxOccurs);
 
         return $this;
     }

--- a/src/BeSimple/SoapCommon/Definition/Part.php
+++ b/src/BeSimple/SoapCommon/Definition/Part.php
@@ -20,12 +20,16 @@ class Part
     protected $name;
     protected $type;
     protected $nillable;
+    protected $minOccurs;
+    protected $maxOccurs;
 
-    public function __construct($name, $type, $nillable = false)
+    public function __construct($name, $type, $nillable = false, $minOccurs = null, $maxOccurs = null)
     {
         $this->name = $name;
         $this->type = $type;
         $this->setNillable($nillable);
+        $this->setMinOccurs($minOccurs);
+        $this->setMaxOccurs($maxOccurs);
     }
 
     public function getName()
@@ -51,5 +55,25 @@ class Part
     public function setNillable($nillable)
     {
         $this->nillable = (boolean) $nillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 }

--- a/src/BeSimple/SoapCommon/WsSecurityFilterClientServer.php
+++ b/src/BeSimple/SoapCommon/WsSecurityFilterClientServer.php
@@ -28,6 +28,16 @@ use BeSimple\SoapCommon\WsSecurityKey;
 abstract class WsSecurityFilterClientServer
 {
     /**
+     * (UT 3.1) Password type: plain text.
+     */
+    const PASSWORD_TYPE_TEXT = 0;
+
+    /**
+     * (UT 3.1) Password type: digest.
+     */
+    const PASSWORD_TYPE_DIGEST = 1;
+
+    /**
      * The date format to be used with {@link \DateTime}
      */
     const DATETIME_FORMAT = 'Y-m-d\TH:i:s.000\Z';

--- a/src/BeSimple/SoapServer/SoapServerBuilder.php
+++ b/src/BeSimple/SoapServer/SoapServerBuilder.php
@@ -67,6 +67,21 @@ class SoapServerBuilder extends AbstractSoapBuilder
             $server->setPersistence($this->persistence);
         }
 
+        if (isset($this->options['wsse'])) {
+            $wssFilter = new WsSecurityFilter();
+            $wssFilter->setPasswordType($this->options['wsse']['password_type']);
+            $wssFilter->setUsernamePasswordCallback(function ($user) {
+                if ($user == $this->options['wsse']['username']) {
+                    return $this->options['wsse']['password'];
+                }
+
+                return null;
+            });
+
+            $soapKernel = $server->getSoapKernel();
+            $soapKernel->registerFilter($wssFilter);
+        }
+
         if (null !== $this->handlerClass) {
             $server->setClass($this->handlerClass);
         } elseif (null !== $this->handlerObject) {
@@ -160,6 +175,18 @@ class SoapServerBuilder extends AbstractSoapBuilder
     public function withMtomAttachments()
     {
         $this->options['attachment_type'] = Helper::ATTACHMENTS_TYPE_MTOM;
+
+        return $this;
+    }
+
+    /**
+     * SOAP attachment type MTOM.
+     *
+     * @return \BeSimple\SoapServer\SoapServerBuilder
+     */
+    public function withWsse($wsse)
+    {
+        $this->options['wsse'] = $wsse;
 
         return $this;
     }

--- a/src/BeSimple/SoapServer/WsSecurityFilter.php
+++ b/src/BeSimple/SoapServer/WsSecurityFilter.php
@@ -204,7 +204,7 @@ class WsSecurityFilter extends WsSecurityFilterClientServer implements SoapReque
 
         // create security header
         $security = $filterHelper->createElement(Helper::NS_WSS, 'Security');
-        $filterHelper->addHeaderElement($security, true, $this->actor, $response->getVersion());
+        $filterHelper->addHeaderElement($security, false, $this->actor, $response->getVersion());
 
         if (true === $this->addTimestamp || null !== $this->expires) {
             $timestamp = $filterHelper->createElement(Helper::NS_WSU, 'Timestamp');

--- a/src/BeSimple/SoapWsdl/Dumper/Dumper.php
+++ b/src/BeSimple/SoapWsdl/Dumper/Dumper.php
@@ -236,7 +236,7 @@ class Dumper
         $complexType = $this->document->createElement(static::XSD_NS.':complexType');
         $complexType->setAttribute('name', $type->getXmlType());
 
-        $all = $this->document->createElement(static::XSD_NS.':'.($type instanceof ArrayOfType ? 'sequence' : 'all'));
+        $all = $this->document->createElement(static::XSD_NS.':sequence');
         $complexType->appendChild($all);
 
         foreach ($type->all() as $child) {

--- a/src/BeSimple/SoapWsdl/Dumper/Dumper.php
+++ b/src/BeSimple/SoapWsdl/Dumper/Dumper.php
@@ -260,6 +260,13 @@ class Dumper
                 $element->setAttribute('nillable', 'true');
             }
 
+            if (null !== $child->getMinOccurs() && 1 != $child->getMinOccurs()) {
+                $element->setAttribute('minOccurs', $child->getMinOccurs());
+            }
+            if (null !== $child->getMaxOccurs() && 1 != $child->getMaxOccurs()) {
+                $element->setAttribute('maxOccurs', $child->getMaxOccurs());
+            }
+
             if ($type instanceof ArrayOfType) {
                 $element->setAttribute('minOccurs', 0);
                 $element->setAttribute('maxOccurs', 'unbounded');


### PR DESCRIPTION
This PR add a way to initialize a WsSecurityFilter (SoapServer) from SoapBundle. In my implementation, you need to give the username and password at service configuration level. Maybe the best would be to allow to pass a user provider, but it could be done in another PR nif needed.

This PR also contains the support for Symfony 3.x and a new ``xsd:time`` type.