### PR TITLE
Prefix can't begin with XML: xmlmime

### DIFF
--- a/src/BeSimple/SoapCommon/Helper.php
+++ b/src/BeSimple/SoapCommon/Helper.php
@@ -104,7 +104,7 @@ class Helper
     /**
      * Describing Media Content of Binary Data in XML namespace.
      */
-    const NS_XMLMIME = 'http://www.w3.org/2004/11/xmlmime';
+    const NS_XMLMIME = 'http://www.w3.org/2005/05/xmlmime';
 
     /**
      * XML Schema namespace.
@@ -144,7 +144,7 @@ class Helper
     /**
      * Describing Media Content of Binary Data in XML namespace prefix.
      */
-    const PFX_XMLMIME = 'xmlmime';
+    const PFX_XMLMIME = 'xmime';
 
     /**
      * XML Schema namespace prefix.


### PR DESCRIPTION
I'm using [BeSimpleSoap](https://github.com/BeSimple/BeSimpleSoap) at work and testing the webservice with [SoapUI](https://www.soapui.org/) the response was never validated. Validation failed with the error:

```
line -1: error: Prefix can't begin with XML: xmlmime
line -1: Prefix can't begin with XML: xmlmime
```

Googling around, I found this page:

https://www.w3.org/TR/xml-media-types/

Which states one should use:

```xml
xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
```

BeSimpleSoap was using:

```xml
xmlns:xmlmime="http://www.w3.org/2004/11/xmlmime"
```

I made that fix locally and now SoapUI validates my webservice response.

I gently ask you to accept this pull request.

Thank you for your good library and keep up the good work!